### PR TITLE
Fix synopsis in App::CLI::Command::Help (PRC)

### DIFF
--- a/lib/App/CLI/Command/Help.pm
+++ b/lib/App/CLI/Command/Help.pm
@@ -16,9 +16,9 @@ App::CLI::Command::Help
     use base qw(App::CLI::Command::Help);
 
     sub run {
-        my ($self, @args) = @_;
+        my $self = shift;
         # preprocess
-        $self->SUPER(@_);       # App::CLI::Command::Help would output POD of each command
+        $self->SUPER::run(@_);  # App::CLI::Command::Help would output POD of each command
     }
 
 =head1 DESCRIPTION


### PR DESCRIPTION
Using the old synopsis would result in the error

    Can't locate object method "SUPER" via package "MyApp::Help" at lib/MyApp/Help.pm line 7.

This patch fixes that so it can be used as is.
