### PR TITLE
Add a more informative default usage text

### DIFF
--- a/lib/App/CLI/Command.pm
+++ b/lib/App/CLI/Command.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Locale::Maketext::Simple;
 use Carp ();
+use File::Basename qw( basename );
 use App::CLI::Helper;
 
 =head1 NAME
@@ -171,7 +172,40 @@ sub usage {
     $buf =~ s/\Q$base\E::(\w+)/\l$1/g;
     $buf =~ s/^AUTHORS.*//sm;
     $buf =~ s/^DESCRIPTION.*//sm unless $want_detail;
-    print $self->loc_text($buf);
+
+    return ($buf ne q{}) ? $self->loc_text($buf) : $self->default_usage;
+}
+
+sub command_name {
+    my ($self) = @_;
+    my $base = ref $self || $self;
+    $base =~ s/^.*:://;
+    return lc $base;
+}
+
+sub default_usage {
+    my ($self) = @_;
+
+    my %options = ($self->global_options, $self->options);
+    my $usage = basename($0) . q{ } . $self->command_name;
+
+    if (%options) {
+      my (@short, @long);
+
+      foreach my $opt (keys %options) {
+        foreach (split qr{\|}, $opt) {
+          (length == 1)
+            ? push @short, $_
+            : push @long,  $_;
+        }
+      }
+
+      $usage .= ' [' . join(q{}, sort @short) . ']' if @short;
+      $usage .= ' [long options]' if @long;
+      $usage .= " ...\n";
+    }
+
+    return $usage;
 }
 
 =head3 loc_text $text

--- a/lib/App/CLI/Command.pm
+++ b/lib/App/CLI/Command.pm
@@ -173,7 +173,10 @@ sub usage {
     $buf =~ s/^AUTHORS.*//sm;
     $buf =~ s/^DESCRIPTION.*//sm unless $want_detail;
 
-    return ($buf ne q{}) ? $self->loc_text($buf) : $self->default_usage;
+    my $usage = ($buf ne q{}) ? $self->loc_text($buf) : $self->default_usage;
+    print $usage;
+
+    return $usage;
 }
 
 sub command_name {


### PR DESCRIPTION
When calling `usage` on commands without POD, the empty string was printed, and when calling the top-level command the string `"[undocumented]"` was printed next to each command.

But all the information to provide a more informative default usage message is already available to App::CLI in the form of the `options` and `global_options` methods.

This patch makes `usage` print the results of `default_usage` when the regular process would result in an empty string.

I had originally intended for this to change the behaviour of `usage` so that it returned the usage string instead of the (largely useless) return value of printing it. But since the printing behaviour is documented, this patch keeps the printing, and makes the function _also_ return the more useful usage text.
