### PR TITLE
Make error_cmd give a more informative error message

### DIFF
--- a/lib/App/CLI.pm
+++ b/lib/App/CLI.pm
@@ -200,7 +200,12 @@ sub cmd_map {
 }
 
 sub error_cmd {
-    "Command not recognized, try $0 --help.\n";
+    my ($self, $pkg) = @_;
+
+    my $cmd = ref($pkg) || $pkg;
+    $cmd //= q{};
+
+    return "Command $cmd not recognized, try $0 --help.\n";
 }
 
 sub error_opt { $_[1] }
@@ -213,7 +218,7 @@ Return subcommand of first level via C<$ARGV[0]>.
 
 sub get_cmd {
     my ($class, $cmd, @arg) = @_;
-    die $class->error_cmd unless $cmd && $cmd =~ m/^[?a-z]+$/;
+    die $class->error_cmd($cmd) unless $cmd && $cmd =~ m/^[?a-z]+$/;
 
     my $pkg = join('::', $class, $class->cmd_map($cmd));
     my $file = "$pkg.pm";

--- a/lib/App/CLI.pm
+++ b/lib/App/CLI.pm
@@ -225,14 +225,9 @@ sub get_cmd {
     $file =~ s!::!/!g;
     eval { require $file; };
 
-    unless ($pkg->can('run')) {
-      warn $@ if $@ and exists $INC{$file};
-      die $class->error_cmd;
-    } else {
-      $cmd = $pkg->new(@arg);
-      $cmd->app($class);
-      return $cmd;
-    }
+    $cmd = $pkg->new(@arg);
+    $cmd->app($class);
+    return $cmd;
 }
 
 

--- a/lib/App/CLI.pm
+++ b/lib/App/CLI.pm
@@ -218,7 +218,7 @@ Return subcommand of first level via C<$ARGV[0]>.
 
 sub get_cmd {
     my ($class, $cmd, @arg) = @_;
-    die $class->error_cmd($cmd) unless $cmd && $cmd =~ m/^[?a-z]+$/;
+    die $class->error_cmd($cmd) unless $cmd && $cmd eq lc($cmd);
 
     my $pkg = join('::', $class, $class->cmd_map($cmd));
     my $file = "$pkg.pm";

--- a/lib/App/CLI/Command.pm
+++ b/lib/App/CLI/Command.pm
@@ -97,7 +97,7 @@ sub cascading {
     my %data = %{$self};
     return bless {%data}, $subcmd;
   } else {
-    die $self->error_cmd;
+    die $self->error_cmd($ARGV[0]);
   }
 }
 

--- a/lib/App/CLI/Command.pm
+++ b/lib/App/CLI/Command.pm
@@ -61,6 +61,11 @@ sub run_command {
     $self->run(@_);
 }
 
+sub run {
+  my $class = shift;
+  Carp::croak ref($class) . " does not implement mandatory method 'run'\n";
+}
+
 =head3 subcommand()
 
     return old genre subcommand of $self;


### PR DESCRIPTION
This patch also adds a default `run` method for `App::CLI::Command` classes that dies with a more informative message when a subclass that doesn't reimplement it is called.

This behaviour is copied from `App::Cmd`.
