### PR TITLE
Weak app ref

### DIFF
--- a/lib/App/CLI.pm
+++ b/lib/App/CLI.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 use 5.006;
 use Class::Load qw( load_class );
-use Scalar::Util qw( weaken );
 
 our $VERSION = '0.45';
 
@@ -234,7 +233,6 @@ sub get_cmd {
 
     $cmd = $pkg->new(@arg);
     $cmd->app($class);
-    weaken($cmd->{app});
     return $cmd;
 }
 

--- a/lib/App/CLI.pm
+++ b/lib/App/CLI.pm
@@ -183,8 +183,7 @@ sub dispatch {
     my $self = shift;
     $self = $self->new unless ref $self;
 
-    $self->app($self);
-    weaken($self->{app});
+    $self->app($self) if $self->can('app');
 
     my $cmd = $self->prepare(@_);
     $cmd->run_command(@ARGV);

--- a/lib/App/CLI/Command.pm
+++ b/lib/App/CLI/Command.pm
@@ -5,6 +5,7 @@ use Locale::Maketext::Simple;
 use Carp ();
 use App::CLI::Helper;
 use Class::Load qw( load_class );
+use Scalar::Util qw( weaken );
 
 =head1 NAME
 
@@ -130,9 +131,13 @@ sub cascadable {
 
 sub app {
     my $self = shift;
-    die Carp::longmess "not a ref" unless ref $self;
-    $self->{app} = shift if @_;
-    return ref ($self->{app}) || $self->{app};
+
+    if (@_) {
+        $self->{app} = shift;
+        weaken($self->{app});
+    }
+
+    return $self->{app};
 }
 
 =head3 brief_usage ($file)


### PR DESCRIPTION
This is just a small improvement on what I had pushed before: it moves the ref weakening to the `app` method, and adds a check so only classes only `app` if they can.
