### PR TITLE
improve App::CLI::Command->brief_usage

### DIFF
--- a/lib/App/CLI/Command.pm
+++ b/lib/App/CLI/Command.pm
@@ -156,8 +156,8 @@ sub brief_usage {
     my $buf  = <$podfh>;
     my $base = ref $self->app;
     my $indent = "    ";
-    if ( $buf =~ /^=head1\s+NAME\s*\Q$base\E::(\w+ - .+)$/m ) {
-        print $indent, loc( lc($1) ), "\n";
+    if ( $buf =~ /^=head1\s+NAME\s*\Q$base\E::(\w+)( - .+)$/m ) {
+        print $indent, loc( lc($1) . $2 ), "\n";
     }
     else {
         my $cmd = $file || $self->filename;


### PR DESCRIPTION
Lower the case for the command name only and keep the short description unmodified